### PR TITLE
Switch from Print to Println

### DIFF
--- a/gopwgen.go
+++ b/gopwgen.go
@@ -92,7 +92,7 @@ func main() {
 	for i := 0; i < numPws; i++ {
 		outputs[i] = pwStringer(pwlen, allowed)
 	}
-	fmt.Print(strings.Join(outputs, "\n"))
+	fmt.Println(strings.Join(outputs, "\n"))
 }
 
 func pwgen(length int, allowedChars string) []byte {


### PR DESCRIPTION
Yes. For some reason, I thought this change was worth a pull request. This makes output work as expected in Bash and ZSH with more recent versions of Go (1.9+?)